### PR TITLE
Fix offline script to ignore NGINX Plus

### DIFF
--- a/scripts/nginx_ingress_offline_download.sh
+++ b/scripts/nginx_ingress_offline_download.sh
@@ -16,7 +16,10 @@ FILES=(
   "deployments/common/nginx-config.yaml"
   "deployments/rbac/rbac.yaml"
   "deployments/daemon-set/nginx-ingress.yaml"
-  "deployments/daemon-set/nginx-plus-ingress.yaml"
+  # The commercial NGINX Plus manifest and related image are intentionally
+  # excluded to keep the script fully usable in air-gapped environments
+  # without requiring a commercial license.
+  # "deployments/daemon-set/nginx-plus-ingress.yaml"
 )
 
 for file in "${FILES[@]}"; do


### PR DESCRIPTION
## Summary
- disable download of NGINX Plus manifest and image in nginx_ingress_offline_download.sh

## Testing
- `shellcheck scripts/nginx_ingress_offline_download.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d7c75ee74832b9173faa2e65e776a