### PR TITLE
Update k8s_packages role for offline install

### DIFF
--- a/roles/k8s_packages/tasks/k8s-install.yml
+++ b/roles/k8s_packages/tasks/k8s-install.yml
@@ -1,18 +1,29 @@
-- name: Install a list of k8s packages
+- name: Install base utilities for Kubernetes
   apt:
-    name: "{{ packages }}"
-  vars:
-    packages:
-    - cri-o
-    - cri-o-runc
-    - kubeadm={{ kube_version }}
-    - kubelet={{ kube_version }}
-    - kubectl={{ kube_version }}
-    - jq # for vault scripts
-    - curl # could be avoided with ansible >=2.11.0
-    - parted #necessary for local persistent volume isolation
+    name:
+      - jq
+      - curl
+      - parted
+  become: true
+
+- name: Install CRI-O packages from offline directory
+  apt:
+    deb: "{{ item }}"
+  loop: "{{ lookup('fileglob', offline_dir + '/crio/packages/*.deb', wantlist=True) }}"
   become: true
   when: container_runtime == "crio"
+
+- name: Install Kubernetes binaries from offline archive
+  copy:
+    src: "{{ offline_dir }}/k8s/bin/{{ item }}"
+    dest: "/usr/bin/{{ item }}"
+    mode: '0755'
+    remote_src: yes
+  loop:
+    - kubeadm
+    - kubelet
+    - kubectl
+  become: true
 
 - name: Enable and check crio service
   systemd:
@@ -31,15 +42,11 @@
   become: true
   when: container_runtime == "crio"
 
-# Hold k8s packages version to prevent update 
+# Hold CRI-O packages version to prevent update
 - dpkg_selections:
     name : "{{ item }}"
     selection: hold
   become: true
-  with_items:
+  loop:
     - cri-o
-    - cri-o-runc
-    - kubeadm
-    - kubelet
-    - kubectl
-  when: container_runtime == "crio"
+    - cri-o-runc  when: container_runtime == "crio"

--- a/roles/k8s_packages/tasks/k8s_repository.yml
+++ b/roles/k8s_packages/tasks/k8s_repository.yml
@@ -1,17 +1,16 @@
-  - name: Add kubeadm apt repository
-    apt_repository:
-      repo: deb {{ repo_k8s_kubeadm }}
-      state: present
-    become: true
+  #- name: Add kubeadm apt repository
+  #  apt_repository:
+  #    repo: deb {{ repo_k8s_kubeadm }}
+  #    state: present
+  #  become: true
 
-  - name: Add cri-o apt repository
-    apt_repository:
-      repo: deb {{ repo_k8s_crio_main }}
-      state: present
-    become: true
-
-  - name: Add cri-o 1.32 apt repository
-    apt_repository:
-      repo: deb {{ repo_k8s_crio }}
-      state: present
-    become: true
+  #- name: Add cri-o apt repository
+  #  apt_repository:
+  #    repo: deb {{ repo_k8s_crio_main }}
+  #    state: present
+  #  become: true
+  #- name: Add cri-o 1.32 apt repository
+  #  apt_repository:
+  #    repo: deb {{ repo_k8s_crio }}
+  #    state: present
+  #  become: true


### PR DESCRIPTION
## Summary
- comment apt repos because Kubernetes will be installed from offline artifacts
- install k8s binaries from `offline/k8s/bin`
- install CRI-O from local `.deb` files
- hold installed CRI-O packages

## Testing
- `ansible-playbook --syntax-check prepare_ci_b49.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7d4a3b84832ba03f08c7b75c5130