### PR TITLE
Switch to containerd runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Run `scripts/offline_download_all.sh` on a machine with internet access to
 download all required container images and manifests. The script stores
 everything under the `offline` directory by default using component specific
-subfolders such as `crio`, `k8s`, `cilium`, `nginx_ingress` and
+subfolders such as `containerd`, `k8s`, `cilium`, `nginx_ingress` and
 `gateway_api`. Copy this directory to each target node and set `offline_dir` in
 your inventory files accordingly. During deployment the playbooks load images
 from these paths with `crictl` so that no internet connection is required.

--- a/inventories/k8s_b49/group_vars/all.yml
+++ b/inventories/k8s_b49/group_vars/all.yml
@@ -17,7 +17,7 @@ offline_dir: /srv/k8s_offline
 
 # Kubernetes
 cluster_name: cluster-dev
-container_runtime: crio
+container_runtime: containerd
 kube_version: 1.32.0-00
 controlPlaneEndpoint: proxy.k8s.dev.lan:6443
 vault_rootpki_endpoint: vault.dev.lan
@@ -28,8 +28,8 @@ pause_img_version: 3.9
 cluster_token: abcdef.0123456789abcdef
 certificateKey: 76e20fb6cbfeef9fbe0931bfe851281fb482b23efaa98e856aba4877574df077
 repo_k8s_kubeadm: http://repos.k8s.dev.lan:8080/kubeadm/  kubernetes-xenial main
-repo_k8s_crio_main: http://repos.k8s.dev.lan:8080/cri-o/ .-- main
-repo_k8s_crio: http://repos.k8s.dev.lan:8080/cri-o_1.32/ .-- main
+#repo_k8s_crio_main: http://repos.k8s.dev.lan:8080/cri-o/ .-- main
+#repo_k8s_crio: http://repos.k8s.dev.lan:8080/cri-o_1.32/ .-- main
 kubeadm_gpg: repo_k8s_dev_lan.gpg
 serviceSubnet: "10.10.0.0/16"
 podSubnet: "10.11.0.0/16"

--- a/inventories/k8s_pf_local_simon/group_vars/all.yml
+++ b/inventories/k8s_pf_local_simon/group_vars/all.yml
@@ -61,7 +61,7 @@ kubeadm_gpg: pcplateform.gpg
 #tmp_dir: /tmp/kubeadm-ansible-files
 #
 ## Container runtimes ('containerd', 'crio')
-container_runtime: crio
+container_runtime: containerd
 #
 ## helm helm version
 #helm_version: "v2.17.0"

--- a/inventories/k8s_tim/group_vars/all.yml
+++ b/inventories/k8s_tim/group_vars/all.yml
@@ -18,7 +18,7 @@ offline_dir: /srv/k8s_offline
 
 # Kubernetes
 cluster_name: cluster.local
-container_runtime: crio
+container_runtime: containerd
 kube_version: 1.32.0-00
 controlPlaneEndpoint: kmsr01.johto.tdmc:6443
 vault_rootpki_endpoint: vault.dev.lan
@@ -29,8 +29,8 @@ pause_img_version: 3.9
 cluster_token: abcdef.0123456789abcdef
 certificateKey: 76e20fb6cbfeef9fbe0931bfe851281fb482b23efaa98e856aba4877574df077
 repo_k8s_kubeadm: http://rpo01.kalos.tdmc:8080/kubeadm/  kubernetes-xenial main
-repo_k8s_crio_main: http://rpo01.kalos.tdmc:8080/cri-o/ .-- main
-repo_k8s_crio: http://rpo01.kalos.tdmc:8080/cri-o_1.32/ .-- main
+#repo_k8s_crio_main: http://rpo01.kalos.tdmc:8080/cri-o/ .-- main
+#repo_k8s_crio: http://rpo01.kalos.tdmc:8080/cri-o_1.32/ .-- main
 kubeadm_gpg: repo_k8s_dev_lan.gpg
 serviceSubnet: "10.10.0.0/16"
 podSubnet: "10.11.0.0/16"

--- a/inventories/kub001_b49/group_vars/all.yml
+++ b/inventories/kub001_b49/group_vars/all.yml
@@ -21,7 +21,7 @@ certificates_autorities:
 
 # Kubernetes
 cluster_name: cluster-kub001
-container_runtime: crio
+container_runtime: containerd
 kube_version: 1.32.0-00
 controlPlaneEndpoint: proxy.kub001.dev.lan:6443
 vault_rootpki_endpoint: vault.dev.lan
@@ -32,8 +32,8 @@ pause_img_version: 3.9
 cluster_token: abcdef.0123456789abcdef
 certificateKey: 76e20fb6cbfeef9fbe0931bfe851281fb482b23efaa98e856aba4877574df077
 repo_k8s_kubeadm: http://repos.k8s.dev.lan:8080/kubeadm/  kubernetes-xenial main
-repo_k8s_crio_main: http://repos.k8s.dev.lan:8080/cri-o/ .-- main
-repo_k8s_crio: http://repos.k8s.dev.lan:8080/cri-o_1.32/ .-- main
+#repo_k8s_crio_main: http://repos.k8s.dev.lan:8080/cri-o/ .-- main
+#repo_k8s_crio: http://repos.k8s.dev.lan:8080/cri-o_1.32/ .-- main
 kubeadm_gpg: repo_k8s_dev_lan.gpg
 serviceSubnet: "10.10.0.0/16"
 podSubnet: "10.11.0.0/16"

--- a/roles/k8s_config/tasks/containerd.yml
+++ b/roles/k8s_config/tasks/containerd.yml
@@ -1,0 +1,13 @@
+- name: Push containerd config file
+  template:
+    src: "containerd_config.toml.j2"
+    dest: "/etc/containerd/config.toml"
+    owner: "{{ ansible_become_user }}"
+    group: "{{ ansible_become_user }}"
+  become: true
+
+- name: Restart service containerd
+  systemd:
+    name: containerd
+    state: restarted
+  become: true

--- a/roles/k8s_config/tasks/main.yml
+++ b/roles/k8s_config/tasks/main.yml
@@ -4,5 +4,5 @@
 - { include: ntp.yml }
 - { include: swapoff.yml}
 - { include: modules.yml}
-- { include: crio.yml}
+- { include: containerd.yml}
 #   when: container_runtime == "crio"

--- a/roles/k8s_config/templates/containerd_config.toml.j2
+++ b/roles/k8s_config/templates/containerd_config.toml.j2
@@ -1,0 +1,2 @@
+[plugins."io.containerd.grpc.v1.cri"]
+  sandbox_image = "{{ registry_k8s }}/pause:{{ pause_img_version }}"

--- a/roles/k8s_init_first_master/templates/kubeadm.yaml.j2
+++ b/roles/k8s_init_first_master/templates/kubeadm.yaml.j2
@@ -12,7 +12,7 @@ localAPIEndpoint:
   advertiseAddress: {{ guest_ip }}
   bindPort: 6443
 nodeRegistration:
-  criSocket: unix:///var/run/crio/crio.sock
+  criSocket: unix:///var/run/{{ container_runtime }}/{{ container_runtime }}.sock
   imagePullPolicy: IfNotPresent
   name: {{ groups['masters'][0] }}
   taints: null

--- a/roles/k8s_join_others_masters/tasks/join_others_masters.yml
+++ b/roles/k8s_join_others_masters/tasks/join_others_masters.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Reset Kubernetes component
-  shell: "kubeadm reset --force --cri-socket=unix:///var/run/crio/crio.sock"
+  shell: "kubeadm reset --force --cri-socket=unix:///var/run/{{ container_runtime }}/{{ container_runtime }}.sock"
   become: true
 
 - name: Generate join token
@@ -18,5 +18,5 @@
 - name: Run kubeadm join control plane
   shell: |
     export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH && \
-    {{ kubeadm_join }} --cri-socket=unix:///var/run/crio/crio.sock --control-plane --certificate-key {{ certificateKey }}
+    {{ kubeadm_join }} --cri-socket=unix:///var/run/{{ container_runtime }}/{{ container_runtime }}.sock --control-plane --certificate-key {{ certificateKey }}
   become: true

--- a/roles/k8s_join_workers/tasks/join_workers.yml
+++ b/roles/k8s_join_workers/tasks/join_workers.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Reset Kubernetes component
-  shell: "kubeadm reset --force --cri-socket=unix:///var/run/crio/crio.sock"
+  shell: "kubeadm reset --force --cri-socket=unix:///var/run/{{ container_runtime }}/{{ container_runtime }}.sock"
   become: true
 
 - name: Ensure Kubernetes offline directory exists
@@ -40,7 +40,7 @@
 - name: Run kubeadm join
   shell: |
     export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH && \
-    {{ kubeadm_join }} --cri-socket=unix:///var/run/crio/crio.sock
+    {{ kubeadm_join }} --cri-socket=unix:///var/run/{{ container_runtime }}/{{ container_runtime }}.sock
   become: true 
 
 - name: Recreate kube-dns

--- a/roles/k8s_packages/tasks/k8s-install.yml
+++ b/roles/k8s_packages/tasks/k8s-install.yml
@@ -6,12 +6,12 @@
       - parted
   become: true
 
-- name: Install CRI-O packages from offline directory
+- name: Install containerd packages from offline directory
   apt:
     deb: "{{ item }}"
-  loop: "{{ lookup('fileglob', offline_dir + '/crio/packages/*.deb', wantlist=True) }}"
+  loop: "{{ lookup('fileglob', offline_dir + '/containerd/packages/*.deb', wantlist=True) }}"
   become: true
-  when: container_runtime == "crio"
+  when: container_runtime == "containerd"
 
 - name: Install Kubernetes binaries from offline archive
   copy:
@@ -25,28 +25,26 @@
     - kubectl
   become: true
 
-- name: Enable and check crio service
+- name: Enable and check containerd service
   systemd:
-    name: crio
+    name: containerd
     daemon_reload: yes
     state: started
     enabled: yes
   register: started_kubelet
   become: true
-  when: container_runtime == "crio"
+  when: container_runtime == "containerd"
 
-- name: Load pre-downloaded CRI-O images
-  shell: "crictl load {{ item }}"
+- name: Load pre-downloaded containerd images
+  shell: "ctr -n k8s.io images import {{ item }}"
   with_fileglob:
-    - "{{ offline_dir }}/crio/images/*.tar"
+    - "{{ offline_dir }}/containerd/images/*.tar"
   become: true
-  when: container_runtime == "crio"
+  when: container_runtime == "containerd"
 
-# Hold CRI-O packages version to prevent update
+# Hold containerd package version to prevent update
 - dpkg_selections:
-    name : "{{ item }}"
+    name: containerd.io
     selection: hold
   become: true
-  loop:
-    - cri-o
-    - cri-o-runc  when: container_runtime == "crio"
+  when: container_runtime == "containerd"

--- a/scripts/containerd_offline_download.sh
+++ b/scripts/containerd_offline_download.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINERD_VERSION="${CONTAINERD_VERSION:-1.6.32-1}"
+OS_FLAVOR="${OS_FLAVOR:-debian}"
+OS_VERSION="${OS_VERSION:-bullseye}"
+ARCH="${ARCH:-amd64}"
+OFFLINE_DIR="${OFFLINE_DIR:-$(pwd)/offline}"
+DOWNLOAD_DIR="$OFFLINE_DIR/containerd"
+
+mkdir -p "$DOWNLOAD_DIR/packages" "$DOWNLOAD_DIR/images"
+
+REPO_BASE="https://download.docker.com/linux/${OS_FLAVOR}/dists/${OS_VERSION}/pool/stable/${ARCH}"
+PACKAGE="containerd.io_${CONTAINERD_VERSION}_${ARCH}.deb"
+
+echo "Downloading $PACKAGE from $REPO_BASE"
+curl -L "$REPO_BASE/$PACKAGE" -o "$DOWNLOAD_DIR/packages/$PACKAGE"
+
+IMAGES=(
+  "registry.k8s.io/pause:3.9"
+)
+
+for img in "${IMAGES[@]}"; do
+  echo "Pulling $img"
+  docker pull "$img"
+  out_name=$(echo "$img" | tr '/:' '_').tar
+  docker save "$img" -o "$DOWNLOAD_DIR/images/$out_name"
+done
+
+echo "All containerd assets downloaded in $DOWNLOAD_DIR"
+echo "Transfer image tarballs to $DOWNLOAD_DIR/images on target nodes and load with:"
+echo "  sudo ctr -n k8s.io images import <image>.tar"

--- a/scripts/offline_download_all.sh
+++ b/scripts/offline_download_all.sh
@@ -8,7 +8,7 @@ export OFFLINE_DIR
 
 "$SCRIPT_DIR/k8s_offline_download.sh"
 "$SCRIPT_DIR/cni_offline_download.sh"
-"$SCRIPT_DIR/crio_offline_download.sh"
+"$SCRIPT_DIR/containerd_offline_download.sh"
 "$SCRIPT_DIR/cilium_offline_download.sh"
 "$SCRIPT_DIR/nginx_ingress_offline_download.sh"
 "$SCRIPT_DIR/download_gateway_api.sh"


### PR DESCRIPTION
## Summary
- switch offline download and roles to containerd
- add containerd offline download script
- install containerd instead of CRI-O
- update kubeadm join and init templates
- update inventories to use containerd

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687659eb82ec832bb485c4f85a8e5e88